### PR TITLE
Add ERC20 Stream Amount Enforcer

### DIFF
--- a/script/EnforcersDeploy.s.sol
+++ b/script/EnforcersDeploy.s.sol
@@ -1,4 +1,3 @@
-// SPDX-License-Identifier: MIT
 pragma solidity >=0.8.23 <0.9.0;
 
 import { console2 } from "forge-std/console2.sol";
@@ -26,6 +25,7 @@ import { OwnershipTransferEnforcer } from "delegation-framework/src/enforcers/Ow
 import { RedeemerEnforcer } from "delegation-framework/src/enforcers/RedeemerEnforcer.sol";
 import { TimestampEnforcer } from "delegation-framework/src/enforcers/TimestampEnforcer.sol";
 import { ValueLteEnforcer } from "delegation-framework/src/enforcers/ValueLteEnforcer.sol";
+import { ERC20StreamAmountEnforcer } from "src/enforcers/ERC20StreamAmountEnforcer.sol";
 
 contract EnforcersDeploy is Script {
     bytes32 salt;
@@ -106,6 +106,10 @@ contract EnforcersDeploy is Script {
 
         deployedAddress = address(new ValueLteEnforcer{ salt: salt }());
         console2.log("ValueLteEnforcer: %s", deployedAddress);
+
+        deployedAddress = address(new ERC20StreamAmountEnforcer{ salt: salt }());
+        console2.log("ERC20StreamAmountEnforcer: %s", deployedAddress);
+
         vm.stopBroadcast();
     }
 }

--- a/src/enforcers/ERC20StreamAmountEnforcer.sol
+++ b/src/enforcers/ERC20StreamAmountEnforcer.sol
@@ -1,0 +1,77 @@
+pragma solidity 0.8.23;
+
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { ExecutionLib } from "@erc7579/lib/ExecutionLib.sol";
+import { CaveatEnforcer } from "./CaveatEnforcer.sol";
+import { ModeCode } from "../utils/Types.sol";
+
+/**
+ * @title ERC20StreamAmountEnforcer
+ * @dev This contract enforces the streaming of ERC20 tokens over a specified time period.
+ */
+contract ERC20StreamAmountEnforcer is CaveatEnforcer {
+    using ExecutionLib for bytes;
+
+    ////////////////////////////// State //////////////////////////////
+
+    mapping(address delegationManager => mapping(bytes32 delegationHash => uint256 amount)) public spentMap;
+
+    ////////////////////////////// Functions //////////////////////////////
+
+    /**
+     * @notice Decodes the terms used in this CaveatEnforcer.
+     * @param _terms encoded data that is used during the execution hooks.
+     * @return allowedContract_ The address of the ERC20 token contract.
+     * @return maxTokens_ The maximum number of tokens that the delegate is allowed to transfer.
+     * @return startEpoch_ The start time of the token stream.
+     * @return endEpoch_ The end time of the token stream.
+     */
+    function getTermsInfo(bytes calldata _terms) public pure returns (address allowedContract_, uint256 maxTokens_, uint128 startEpoch_, uint128 endEpoch_) {
+        require(_terms.length == 72, "ERC20StreamAmountEnforcer:invalid-terms-length");
+
+        allowedContract_ = address((bytes20(_terms[:20])));
+        maxTokens_ = uint256(bytes32(_terms[20:52]));
+        startEpoch_ = uint128(bytes16(_terms[52:68]));
+        endEpoch_ = uint128(bytes16(_terms[68:]));
+    }
+
+    /**
+     * @notice Validates and increases the spent amount for the token stream.
+     * @param _terms The terms of the token stream.
+     * @param _executionCallData The transaction the delegate might try to perform.
+     * @param _delegationHash The hash of the delegation being operated on.
+     * @return limit_ The maximum amount of tokens that the delegator is allowed to spend.
+     * @return spent_ The amount of tokens that the delegator has spent.
+     */
+    function _validateAndIncrease(
+        bytes calldata _terms,
+        bytes calldata _executionCallData,
+        bytes32 _delegationHash
+    )
+        internal
+        returns (uint256 limit_, uint256 spent_)
+    {
+        (address target_,, bytes calldata callData_) = _executionCallData.decodeSingle();
+
+        require(callData_.length == 68, "ERC20StreamAmountEnforcer:invalid-execution-length");
+
+        address allowedContract_;
+        uint128 startEpoch_;
+        uint128 endEpoch_;
+        (allowedContract_, limit_, startEpoch_, endEpoch_) = getTermsInfo(_terms);
+
+        require(allowedContract_ == target_, "ERC20StreamAmountEnforcer:invalid-contract");
+
+        require(bytes4(callData_[0:4]) == IERC20.transfer.selector, "ERC20StreamAmountEnforcer:invalid-method");
+
+        require(block.timestamp >= startEpoch_, "ERC20StreamAmountEnforcer:stream-not-started");
+        require(block.timestamp <= endEpoch_, "ERC20StreamAmountEnforcer:stream-ended");
+
+        uint256 streamDuration = endEpoch_ - startEpoch_;
+        uint256 elapsedTime = block.timestamp - startEpoch_;
+        uint256 allowedAmount = (limit_ * elapsedTime) / streamDuration;
+
+        spent_ = spentMap[msg.sender][_delegationHash] += uint256(bytes32(callData_[36:68]));
+        require(spent_ <= allowedAmount, "ERC20StreamAmountEnforcer:allowance-exceeded");
+    }
+}

--- a/test/ERC20StreamAmountEnforcer.t.sol
+++ b/test/ERC20StreamAmountEnforcer.t.sol
@@ -1,0 +1,168 @@
+pragma solidity 0.8.23;
+
+import { BaseTest, ERC20Mintable } from "test/utils/BaseTest.t.sol";
+import { ERC20StreamAmountEnforcer } from "src/enforcers/ERC20StreamAmountEnforcer.sol";
+import { ExecutionLib } from "@erc7579/lib/ExecutionLib.sol";
+import { Delegation, Caveat, Execution, PackedUserOperation, ModeCode } from "delegation-framework/src/utils/Types.sol";
+import { EncoderLib } from "delegation-framework/src/libraries/EncoderLib.sol";
+import { ERC1271Lib } from "delegation-framework/src/libraries/ERC1271Lib.sol";
+import { ModeLib } from "@erc7579/lib/ModeLib.sol";
+
+contract ERC20StreamAmountEnforcer_Test is BaseTest {
+    using ModeLib for ModeCode;
+
+    ERC20StreamAmountEnforcer streamAmountEnforcer;
+    ModeCode[] _oneSingularMode;
+
+    function setUp() public virtual override {
+        super.setUp();
+
+        streamAmountEnforcer = new ERC20StreamAmountEnforcer();
+        _oneSingularMode = new ModeCode[](1);
+        _oneSingularMode[0] = ModeLib.encodeSimpleSingle();
+    }
+
+    function test_getTermsInfo() external {
+        bytes memory terms = abi.encodePacked(
+            address(erc20),
+            uint256(100e18),
+            uint128(1733011200),
+            uint128(1734134400)
+        );
+
+        (address allowedContract, uint256 maxTokens, uint128 startEpoch, uint128 endEpoch) = streamAmountEnforcer.getTermsInfo(terms);
+
+        assertEq(allowedContract, address(erc20));
+        assertEq(maxTokens, 100e18);
+        assertEq(startEpoch, 1733011200);
+        assertEq(endEpoch, 1734134400);
+    }
+
+    function test_validateAndIncrease() external {
+        bytes memory terms = abi.encodePacked(
+            address(erc20),
+            uint256(100e18),
+            uint128(1733011200),
+            uint128(1734134400)
+        );
+
+        bytes memory callData = abi.encodeWithSelector(
+            ERC20Mintable.mint.selector,
+            address(users.alice.wallet),
+            10e18
+        );
+
+        bytes memory executionCallData = ExecutionLib.encodeSingle(
+            address(erc20),
+            0,
+            callData
+        );
+
+        bytes32 delegationHash = keccak256("delegationHash");
+
+        vm.warp(1733011200 + 1000000); // Move to a time within the stream period
+
+        (uint256 limit, uint256 spent) = streamAmountEnforcer._validateAndIncrease(terms, executionCallData, delegationHash);
+
+        assertEq(limit, 100e18);
+        assertEq(spent, 10e18);
+    }
+
+    function test_validateAndIncrease_streamNotStarted() external {
+        bytes memory terms = abi.encodePacked(
+            address(erc20),
+            uint256(100e18),
+            uint128(1733011200),
+            uint128(1734134400)
+        );
+
+        bytes memory callData = abi.encodeWithSelector(
+            ERC20Mintable.mint.selector,
+            address(users.alice.wallet),
+            10e18
+        );
+
+        bytes memory executionCallData = ExecutionLib.encodeSingle(
+            address(erc20),
+            0,
+            callData
+        );
+
+        bytes32 delegationHash = keccak256("delegationHash");
+
+        vm.warp(1733011199); // Move to a time before the stream period
+
+        vm.expectRevert("ERC20StreamAmountEnforcer:stream-not-started");
+        streamAmountEnforcer._validateAndIncrease(terms, executionCallData, delegationHash);
+    }
+
+    function test_validateAndIncrease_streamEnded() external {
+        bytes memory terms = abi.encodePacked(
+            address(erc20),
+            uint256(100e18),
+            uint128(1733011200),
+            uint128(1734134400)
+        );
+
+        bytes memory callData = abi.encodeWithSelector(
+            ERC20Mintable.mint.selector,
+            address(users.alice.wallet),
+            10e18
+        );
+
+        bytes memory executionCallData = ExecutionLib.encodeSingle(
+            address(erc20),
+            0,
+            callData
+        );
+
+        bytes32 delegationHash = keccak256("delegationHash");
+
+        vm.warp(1734134401); // Move to a time after the stream period
+
+        vm.expectRevert("ERC20StreamAmountEnforcer:stream-ended");
+        streamAmountEnforcer._validateAndIncrease(terms, executionCallData, delegationHash);
+    }
+
+    function test_validateAndIncrease_allowanceExceeded() external {
+        bytes memory terms = abi.encodePacked(
+            address(erc20),
+            uint256(100e18),
+            uint128(1733011200),
+            uint128(1734134400)
+        );
+
+        bytes memory callData = abi.encodeWithSelector(
+            ERC20Mintable.mint.selector,
+            address(users.alice.wallet),
+            50e18
+        );
+
+        bytes memory executionCallData = ExecutionLib.encodeSingle(
+            address(erc20),
+            0,
+            callData
+        );
+
+        bytes32 delegationHash = keccak256("delegationHash");
+
+        vm.warp(1733011200 + 1000000); // Move to a time within the stream period
+
+        streamAmountEnforcer._validateAndIncrease(terms, executionCallData, delegationHash);
+
+        callData = abi.encodeWithSelector(
+            ERC20Mintable.mint.selector,
+            address(users.alice.wallet),
+            60e18
+        );
+
+        executionCallData = ExecutionLib.encodeSingle(
+            address(erc20),
+            0,
+            callData
+        );
+
+        vm.expectRevert("ERC20StreamAmountEnforcer:allowance-exceeded");
+        streamAmountEnforcer._validateAndIncrease(terms, executionCallData, delegationHash);
+    }
+}


### PR DESCRIPTION
Related to #2

Add ERC20StreamAmountEnforcer module to stream ERC20 tokens over a specified time period.

* Create `ERC20StreamAmountEnforcer.sol` to implement streaming functionality with `getTermsInfo` and `_validateAndIncrease` methods.
* Add unit tests for `ERC20StreamAmountEnforcer.sol` in `test/ERC20StreamAmountEnforcer.t.sol` to ensure complete coverage.
* Update `script/EnforcersDeploy.s.sol` to include deployment of `ERC20StreamAmountEnforcer`.

